### PR TITLE
Enable proxy and promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Send and receive Slack Webhooks easily!",
   "main": "slack.js",
   "dependencies": {
+    "deferred": "^0.7.1",
     "request": "~2.x"
   },
   "devDependencies": {},

--- a/slack.js
+++ b/slack.js
@@ -1,61 +1,67 @@
-var request=require('request');
+"use strict";
 
-function Slack(domain,token) {
-	this.domain = domain;
-	this.token = token;	
+var request  = require('request');
+var deferred = require('deferred');
+
+function Slack(domain, token, option) {
+  this.domain = domain;
+  this.token = token;
+  this.option = option;
 }
 
-Slack.prototype.send = function(message,cb) {
-	
-	
-	if (!message.text) {
-		if (cb) cb.call(null,{message:'No text specified'},null);
-		return;
-	}
-	if (!message.channel) { message.channel = '#general'; }
-		
-	var command = 'https://' + this.domain + '.slack.com/services/hooks/incoming-webhook?token=' + this.token;
-	var options = {
-		
-		"channel":message.channel,
-		"text": message.text,
-		"username":message.username
-			
-	};
-	
-	request.post({url:command,body:JSON.stringify(options)},function(e,r,body) {
+Slack.prototype.send = function(message, cb) {
+  if (!message.text) {
+    if (cb) cb.call(null,{message:'No text specified'},null);
+    return;
+  }
+  if (!message.channel) { message.channel = '#general'; }
 
-		// done!
-		if (!e && body!='ok') {
-			e = {message:body};
-			body = null;
-		}
-		if (cb) cb.call(null,e,body);
-				
-	});
-	
-}
+  var command = 'https://' + this.domain + '.slack.com/services/hooks/incoming-webhook?token=' + this.token;
+  var body = {
+    channel:  message.channel,
+    text:     message.text,
+    username: message.username
+  };
+
+  var option = {
+    proxy: (this.option && this.option.proxy) || process.env.https_proxy || process.env.http_proxy,
+    url:   command,
+    body:  JSON.stringify(body)
+  };
+
+  if(!cb) var d = deferred();
+
+  var req = request.post(option, function(err, res, body) {
+    if (!err && body!='ok') {
+      err = {message: body};
+      body = null;
+    }
+    if (d) return err ? d.reject(err) : d.resolve({res: res, body: body});
+    if (cb) return cb.call(null, err, body);
+    return null;
+  });
+
+  return d ? d.promise : req;
+};
 
 
 Slack.prototype.respond = function(query,cb) {
-	
-	var obj = {};
-	
-	obj.token = query.token;
-	obj.team_id = query.team_id;
-	obj.channel_id = query.channel_id;
-	obj.channel_name = query.channel_name;
-	obj.timestamp = new Date(query.timestamp);
-	obj.user_id = query.user_id;
-	obj.user_name = query.user_name;
-	obj.text = query.text;
-	
-	if (!cb) {
-		return {text:''};
-	} else {
-		return cb.call(null,obj);
-	}
-	
-}
+  var obj = {};
+
+  obj.token = query.token;
+  obj.team_id = query.team_id;
+  obj.channel_id = query.channel_id;
+  obj.channel_name = query.channel_name;
+  obj.timestamp = new Date(query.timestamp);
+  obj.user_id = query.user_id;
+  obj.user_name = query.user_name;
+  obj.text = query.text;
+
+  if (!cb) {
+    return {text:''};
+  } else {
+    return cb.call(null,obj);
+  }
+};
 
 module.exports = Slack;


### PR DESCRIPTION
I modified two points:
1. enable proxy via config

``` javascript
var slack = new Slack("<domain>", "<token>", {proxy: "<proxy>"})
```

or use environment variable `https_proxy` or `http_proxy`.
2. enable promise

``` javascript
var slack = new Slack("<domain>", "<token>", {proxy: "<proxy>"})
slack.send({channel: "#test", text: "msg", username: "muddydixon"})
  .then(function(obj){
    console.log(obj); // obj contain res and body by request
  });
```
