### PR TITLE
Send slack options like link_names with request body

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,8 @@ slack.send({
 	username: 'Bot',
 	icon_emoji: 'taco',
 	attachments: attachment_array,
-	unfurl_links: true
+	unfurl_links: true,
+	link_names: 1
 });
 ```
 

--- a/slack.js
+++ b/slack.js
@@ -23,16 +23,17 @@ Slack.prototype.send = function(message, cb) {
     username: message.username
   };
 
+  if (message.icon_url) { body.icon_url = message.icon_url; }
+  if (message.icon_emoji) { body.icon_emoji = message.icon_emoji; }
+  if (message.attachments) { body.attachments = message.attachments; }
+  if (message.unfurl_links) { body.unfurl_links = message.unfurl_links; }
+  if (message.link_names) { body.link_names = message.link_names; }
+
   var option = {
     proxy: (this.http_proxy_options && this.http_proxy_options.proxy) || process.env.https_proxy || process.env.http_proxy,
     url:   command,
     body:  JSON.stringify(body)
   };
-
-	if (message.icon_url) { options.icon_url = message.icon_url; }
-	if (message.icon_emoji) { options.icon_emoji = message.icon_emoji; }
-	if (message.attachments) { options.attachments = message.attachments; }
-  if (message.unfurl_links) { options.unfurl_links = message.unfurl_links; }
 
   if(!cb) var d = deferred();
 


### PR DESCRIPTION
Issue: Slack message options like `icon_url`, `icon_emoji` and `attachments` were not being included in the request body, because `options` was undefined.

This fix ensures the params are included in the body and adds support for the `link_names` param (auto-linking for Usernames), as defined here https://api.slack.com/methods/chat.postMessage
