### PR TITLE
Use hook url from incoming webhook to send messages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,15 +15,12 @@ npm install node-slack
 ```
 
 
-Get your custom domain and token from Slack.
-
-Domain is the first part of your <domain>.slack.com.
-
-Token is provided on the integration setup page.
+Get your hook url from Slack.
+Create an [incoming webhook](slack.com/services/new/incoming-webhook) to get one.
 
 ```
 var Slack = require('node-slack');
-var slack = new Slack(domain,token);
+var slack = new Slack(hookUrl);
 ```
 
 If your system requires that requests be made through
@@ -32,7 +29,7 @@ variables https_proxy and http_proxy,
 or pass in the optional third option:
 
 ```
-var slack = new Slack(domain,token,{proxy: http_proxy});
+var slack = new Slack(hookUrl,{proxy: http_proxy});
 ```
 
 To send a message, call slack.send:

--- a/slack.js
+++ b/slack.js
@@ -3,9 +3,8 @@
 var request  = require('request');
 var deferred = require('deferred');
 
-function Slack(domain, token, http_proxy_options) {
-  this.domain = domain;
-  this.token = token;
+function Slack(hookUrl, http_proxy_options) {
+  this.hookUrl = hookUrl;
   this.http_proxy_options = http_proxy_options;
 }
 
@@ -16,7 +15,6 @@ Slack.prototype.send = function(message, cb) {
   }
   if (!message.channel) { message.channel = '#general'; }
 
-  var command = 'https://' + this.domain + '.slack.com/services/hooks/incoming-webhook?token=' + this.token;
   var body = {
     channel:  message.channel,
     text:     message.text,
@@ -31,7 +29,7 @@ Slack.prototype.send = function(message, cb) {
 
   var option = {
     proxy: (this.http_proxy_options && this.http_proxy_options.proxy) || process.env.https_proxy || process.env.http_proxy,
-    url:   command,
+    url:   this.hookUrl,
     body:  JSON.stringify(body)
   };
 


### PR DESCRIPTION
Use [incoming webhook](slack.com/services/new/incoming-webhook) instead of user token access

Fixes #7 