### PR TITLE
Allow empty string to be passed as message text for Slack Incoming Webhooks; disallow null

### DIFF
--- a/slack.js
+++ b/slack.js
@@ -9,7 +9,7 @@ function Slack(hook_url, http_proxy_options) {
 }
 
 Slack.prototype.send = function(message, cb) {
-  if (!message.text) {
+  if (message.text == null) {
     if (cb) cb.call(null,{message:'No text specified'},null);
     return;
   }
@@ -18,7 +18,7 @@ Slack.prototype.send = function(message, cb) {
   var body = {
     text:     message.text,
   };
-  
+
   if (message.username) { body.username = message.username; }
   if (message.channel) { body.channel = message.channel; }
   if (message.icon_url) { body.icon_url = message.icon_url; }


### PR DESCRIPTION
Slack allows an empty string to be passed as the text parameter to an incoming webhook, but in `Slack.prototype.send` the code `if (!message.text)` evaluates to true if `message.text == ''` and so no request is made. The pull request changes the conditional to check that the message text isn't null instead of casting an empty string into a boolean.
