### PR TITLE
Relative URL to Absolute URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ slack.send({
 ```
 
 You can also specify an emoji icon, a url to a custom icon, attachments,
-and any of the other options listed [here](slack.com/services/new/incoming-webhook).
+and any of the other options listed [here](https://slack.com/services/new/incoming-webhook).
 
 
 ```


### PR DESCRIPTION
The link doesn't work since there's no protocol so it goes to https://github.com/xoxco/node-slack/blob/master/slack.com/services/new/incoming-webhook instead of https://slack.com/services/new/incoming-webhook